### PR TITLE
Update kvm2 package dependency handling for Debian squeeze/buster

### DIFF
--- a/tasks/kvm2.yml
+++ b/tasks/kvm2.yml
@@ -11,6 +11,7 @@
         - '{{role_path}}/vars'
   loop_control:
     loop_var: kvm_vars
+  when: minikube_kvm2_pkgs is undefined
 
 - name: install kvm2 OS pkg dependencies
   become: yes

--- a/vars/Debian-jessie.yml
+++ b/vars/Debian-jessie.yml
@@ -1,0 +1,4 @@
+---
+minikube_kvm2_pkgs:
+  - libvirt-bin
+  - qemu-kvm

--- a/vars/Debian-stretch.yml
+++ b/vars/Debian-stretch.yml
@@ -1,5 +1,0 @@
----
-minikube_kvm2_pkgs:
-  - libvirt-daemon-system
-  - libvirt-clients
-  - qemu-kvm

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,5 @@
 ---
 minikube_kvm2_pkgs:
-  - libvirt-bin
+  - libvirt-daemon-system
+  - libvirt-clients
   - qemu-kvm

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,4 @@
+---
+minikube_kvm2_pkgs:
+  - libvirt-bin
+  - qemu-kvm


### PR DESCRIPTION
Make 'Debian.yml' the future-looking set of packages for versions of Debian (libvirt-bin doesn't exist in current stable and testing), and add a separate dependency file for Ubuntu (where libvirt-bin still exists, but just depends on the relevant packages).

In this case, I was trying to run the playbook against a Debian sid system.

I also added the ability for someone to override (locally) the `include_vars` task; without this, I couldn't find a way for a local variable declaration to win over the one imported during an ansible run.